### PR TITLE
Fix: Cache-Control can be Array

### DIFF
--- a/src/AbstractStore.php
+++ b/src/AbstractStore.php
@@ -65,7 +65,7 @@ abstract class AbstractStore implements StoreInterface
         if ($res->hasHeader('Cache-Control')) {
             if (preg_match(
                 '/max-age\s*=\s*(\d+)/',
-                $res->getHeader('Cache-Control'),
+                $res->getHeaderLine('Cache-Control'),
                 $matches
             )) {
                 $ttl = intval($matches[1]);


### PR DESCRIPTION
guzzle's getHeader can return an array, and does so for Cache-Control. This is a naive fix turning the header into a string if necessary, to fix the preg_match function.