### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - composer install -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ php:
   - 7.1
   - 7.2
 
+before_install:
+  - echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
 before_script:
   - composer install -n
 
 script:
   - ./vendor/bin/phpcs --standard=psr2 . --ignore=/vendor/
+  - ./vendor/bin/phpstan analyse --level max src/
   - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "spomky-labs/base64url": "^1.0",
-        "fgrosse/phpasn1": "^1.5",
+        "fgrosse/phpasn1": "^2.0",
         "lcobucci/jwt": "^3.2",
         "guzzlehttp/guzzle": "^6.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6",
-        "squizlabs/php_codesniffer": "^2.7"
+        "phpunit/phpunit": "^6.3",
+        "squizlabs/php_codesniffer": "^3.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",
+        "phpstan/phpstan": "^0.8",
         "squizlabs/php_codesniffer": "^3.1"
     }
 }

--- a/src/AbstractStore.php
+++ b/src/AbstractStore.php
@@ -42,7 +42,7 @@ abstract class AbstractStore implements StoreInterface
      * @param  string $email  Optional email context
      * @return string         The generated nonce.
      */
-    public function generateNonce($email)
+    public function generateNonce(string $email): string
     {
         return bin2hex(random_bytes(16));
     }
@@ -52,7 +52,7 @@ abstract class AbstractStore implements StoreInterface
      * @param  string $url  The URL to fetch.
      * @return object       An object with `ttl` and `data` properties.
      */
-    public function fetch($url)
+    public function fetch(string $url)
     {
         $res = $this->guzzle->get($url);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -31,10 +31,10 @@ class Client
 
     /**
      * Constructor
-     * @param Store  $store        Store implementation to use.
-     * @param string $redirectUri  URL that Portier will redirect to.
+     * @param StoreInterface  $store        Store implementation to use.
+     * @param string          $redirectUri  URL that Portier will redirect to.
      */
-    public function __construct($store, $redirectUri)
+    public function __construct(StoreInterface $store, string $redirectUri)
     {
         $this->store = $store;
         $this->redirectUri = $redirectUri;
@@ -47,7 +47,7 @@ class Client
      * @param  string $email  Email address to authenticate.
      * @return string         URL to redirect the browser to.
      */
-    public function authenticate($email)
+    public function authenticate(string $email): string
     {
         $nonce = $this->store->createNonce($email);
         $query = http_build_query([
@@ -67,7 +67,7 @@ class Client
      * @param  string $token  The received `id_token` parameter value.
      * @return string         The verified email address.
      */
-    public function verify($token)
+    public function verify(string $token): string
     {
         // Parse token and get the key ID from its header.
         $parser = new \Lcobucci\JWT\Parser();
@@ -123,11 +123,9 @@ class Client
     }
 
     /**
-     * Parse a JWK into an OpenSSL public key.
-     * @param  object   $jwk
-     * @return resource
+     * Parse a JWK into a PEM public key.
      */
-    private static function parseJwk($jwk)
+    private static function parseJwk($jwk): string
     {
         $n = gmp_init(bin2hex(\Base64Url\Base64Url::decode($jwk->n)), 16);
         $e = gmp_init(bin2hex(\Base64Url\Base64Url::decode($jwk->e)), 16);
@@ -139,19 +137,16 @@ class Client
 
         $encoded = base64_encode($pkey->getBinary());
 
-        return new \Lcobucci\JWT\Signer\Key(
+        return
             "-----BEGIN PUBLIC KEY-----\n" .
             chunk_split($encoded, 64, "\n") .
-            "-----END PUBLIC KEY-----\n"
-        );
+            "-----END PUBLIC KEY-----\n";
     }
 
     /**
      * Get the origin for a URL
-     * @param  string $url
-     * @return string
      */
-    private static function getOrigin($url)
+    private static function getOrigin(string $url): string
     {
         $components = parse_url($url);
         if ($components === false) {

--- a/src/RedisStore.php
+++ b/src/RedisStore.php
@@ -23,7 +23,7 @@ class RedisStore extends AbstractStore
     /**
      * {@inheritDoc}
      */
-    public function fetchCached($cacheId, $url)
+    public function fetchCached(string $cacheId, string $url)
     {
         $key = 'cache:' . $cacheId;
 
@@ -41,7 +41,7 @@ class RedisStore extends AbstractStore
     /**
      * {@inheritDoc}
      */
-    public function createNonce($email)
+    public function createNonce(string $email): string
     {
         $nonce = $this->generateNonce($email);
 
@@ -54,7 +54,7 @@ class RedisStore extends AbstractStore
     /**
      * {@inheritDoc}
      */
-    public function consumeNonce($nonce, $email)
+    public function consumeNonce(string $nonce, string $email)
     {
         $key = 'nonce:' . $nonce;
         $res = $this->redis->multi()

--- a/src/StoreInterface.php
+++ b/src/StoreInterface.php
@@ -13,19 +13,19 @@ interface StoreInterface
      * @param  string $url      The URL to fetch of the ID is not available.
      * @return object           The JSON object from the response body.
      */
-    public function fetchCached($cacheId, $url);
+    public function fetchCached(string $cacheId, string $url);
 
     /**
      * Generate and store a nonce.
      * @param  string $email  Email address to associate with the nonce.
      * @return string         The generated nonce.
      */
-    public function createNonce($email);
+    public function createNonce(string $email): string;
 
     /**
      * Consume a nonce, and check if it's valid for the given email address.
      * @param string $nonce  The nonce to resolve.
      * @param string $email  The email address that is being verified.
      */
-    public function consumeNonce($nonce, $email);
+    public function consumeNonce(string $nonce, string $email);
 }


### PR DESCRIPTION
This upgrades phpasn1 to 2.0, which contains PHP 7.2 compatibility changes.

Because phpasn1 now requires PHP >=7.0, we do too. So I've take the liberty of adding typehints everywhere.

This also means we need to do a 0.2.0 after this. :)