### PR TITLE
Add signing algorithm selection

### DIFF
--- a/client-tester.php
+++ b/client-tester.php
@@ -9,10 +9,8 @@ if (2 !== count($argv)) {
 
 require_once __DIR__.'/vendor/autoload.php';
 
-$client = new \Portier\Client\Client(
-    new \Portier\Client\MemoryStore(),
-    'http://imaginary-client.test/fake-verify-route'
-);
+$store = new Portier\Client\MemoryStore();
+$client = new Portier\Client\Client($store, 'http://imaginary-client.test/fake-verify-route');
 $client->broker = $argv[1];
 
 $stdin = fopen('php://stdin', 'r');
@@ -39,6 +37,10 @@ while (($line = fgets($stdin, 4096)) !== false) {
                 $msg = implode('  ', explode("\n", $err->getMessage()));
                 echo "err\t{$msg}\n";
             }
+            break;
+        case 'clear-cache':
+            $store->clearCache();
+            echo "ok\n";
             break;
         default:
             error_log("invalid command: {$cmd[0]}");

--- a/src/JWK.php
+++ b/src/JWK.php
@@ -11,6 +11,9 @@ final class JWK
     {
     }
 
+    /**
+     * Convert a JWK to PEM format.
+     */
     public static function toPem(\stdClass $jwk): string
     {
         if (!isset($jwk->kty) || !is_string($jwk->kty)) {
@@ -136,7 +139,7 @@ final class JWK
     }
 
     /**
-     * @internal for tests only
+     * Decode base64url.
      */
     public static function decodeBase64Url(string $input): string
     {

--- a/src/StoreInterface.php
+++ b/src/StoreInterface.php
@@ -20,17 +20,19 @@ interface StoreInterface
     /**
      * Generate and store a nonce.
      *
-     * @param string $email email address to associate with the nonce
+     * @param string $clientId client ID to associate with the nonce
+     * @param string $email    email address to associate with the nonce
      *
      * @return string the generated nonce
      */
-    public function createNonce(string $email): string;
+    public function createNonce(string $clientId, string $email): string;
 
     /**
-     * Consume a nonce, and check if it's valid for the given email address.
+     * Consume a nonce, and check if it's valid for the given client ID and email address.
      *
-     * @param string $nonce the nonce to resolve
-     * @param string $email the email address that is being verified
+     * @param string $nonce    the nonce to resolve
+     * @param string $clientId client ID that is being verified
+     * @param string $email    the email address that is being verified
      */
-    public function consumeNonce(string $nonce, string $email): void;
+    public function consumeNonce(string $nonce, string $clientId, string $email): void;
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -43,19 +43,29 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             {
                 $this->fetchCachedCalled = true;
 
-                return (object) [
-                    'authorization_endpoint' => 'http://imaginary-server.test/auth',
-                ];
+                switch (parse_url($url, PHP_URL_PATH)) {
+                    case '/.well-known/openid-configuration':
+                        return (object) [
+                            'authorization_endpoint' => 'http://imaginary-server.test/auth',
+                            'jwks_uri' => 'http://imaginary-server.test/jwks',
+                        ];
+                    case '/jwks':
+                        return (object) [
+                            'keys' => [],
+                        ];
+                    default:
+                        throw new \Exception('Unexpected request: '.$url);
+                }
             }
 
-            public function createNonce(string $email): string
+            public function createNonce(string $clientId, string $email): string
             {
                 $this->createNonceCalled = true;
 
                 return 'foobar';
             }
 
-            public function consumeNonce(string $nonce, string $email): void
+            public function consumeNonce(string $nonce, string $clientId, string $email): void
             {
                 throw new \Exception('Not implemented');
             }


### PR DESCRIPTION
Implementation for: https://github.com/portier/portier.github.io/pull/46
Passes the matching client-tester branch: https://github.com/portier/client-tester/pull/6

This also drops the `phpasn1` dependency which has long been marked as unmaintained, and replaces it with our own JWK->PEM converter, which also doesn't require any bignum php extension.